### PR TITLE
Upgrade python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ v4-cokapi/backends/javascript/node-v6.0.0-darwin-x64/
 
 # this .gz file is too big to fit into a github repo
 v4-cokapi/backends/java/jdk-8u20-linux-x64.tar.gz
+
+venv

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@
 # and commit this file to your remote git repository to share the goodness with others.
 
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
-image: gitpod/workspace-python-3.7
+image: gitpod/workspace-python-3.11
 
 tasks:
   - init: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bottle==0.12.17
-gunicorn==19.9.0
+bottle==0.12.25
+gunicorn==19

--- a/v5-unity/pg_logger.py
+++ b/v5-unity/pg_logger.py
@@ -53,7 +53,7 @@ import pg_encoder
 # upper-bound on the number of executed lines, in order to guard against
 # infinite loops
 #MAX_EXECUTED_LINES = 300
-MAX_EXECUTED_LINES = 1000 # on 2016-05-01, I increased the limit from 300 to 1000 for Python due to popular user demand! and I also improved the warning message
+MAX_EXECUTED_LINES = 3000 # on 2016-05-01, I increased the limit from 300 to 1000 for Python due to popular user demand! and I also improved the warning message
 
 #DEBUG = False
 DEBUG = True
@@ -167,7 +167,7 @@ else:
 ALLOWED_STDLIB_MODULE_IMPORTS = ('math', 'random', 'time', 'datetime',
                           'functools', 'itertools', 'operator', 'string',
                           'collections', 're', 'json',
-                          'heapq', 'bisect', 'copy', 'hashlib', 'typing',
+                          'heapq', 'bisect', 'copy', 'hashlib', 'typing', 'os', 'sys', 'platform',
                           # the above modules were first added in 2012-09
                           # and then incrementally appended to up until
                           # 2016-ish (see git blame logs)

--- a/v5-unity/pg_logger.py
+++ b/v5-unity/pg_logger.py
@@ -167,7 +167,7 @@ else:
 ALLOWED_STDLIB_MODULE_IMPORTS = ('math', 'random', 'time', 'datetime',
                           'functools', 'itertools', 'operator', 'string',
                           'collections', 're', 'json',
-                          'heapq', 'bisect', 'copy', 'hashlib', 'typing', 'os', 'sys', 'platform',
+                          'heapq', 'bisect', 'copy', 'hashlib', 'typing',
                           # the above modules were first added in 2012-09
                           # and then incrementally appended to up until
                           # 2016-ish (see git blame logs)

--- a/v5-unity/visualize.html
+++ b/v5-unity/visualize.html
@@ -8,7 +8,7 @@
 -->
 
 <head>
-  <title>Visualize Python, Java, JavaScript, C, C++, Ruby code execution</title>
+  <title>Visualize Python code execution</title>
 
   <meta http-equiv="Content-type" content="text/html; charset=UTF-8"/>
 
@@ -23,7 +23,6 @@
 
 <body>
 
-<img src="static/images/pathrise_logo.png" style="max-height: 500px; max-width: 500px;" align='middle'>
 
 <!-- <table id="experimentalHeader"> -->
 <tr>


### PR DESCRIPTION
Upgrade Python to 3.11, which offers much better error messages and type hints support